### PR TITLE
Fixed login and bumped version to 2.1 across the board

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 setup(
     name='pymetasploit',
     author='Nadeem Douba',
-    version='2.0',
+    version='2.1',
     author_email='ndouba@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',

--- a/src/metasploit/__init__.py
+++ b/src/metasploit/__init__.py
@@ -5,7 +5,7 @@ __copyright__ = 'Copyright 2021, PyMetasploit Project'
 __credits__ = []
 
 __license__ = 'GPL'
-__version__ = '2.0'
+__version__ = '2.1'
 __maintainer__ = 'Nadeem Douba'
 __email__ = 'ndouba@gmail.com'
 __status__ = 'Development'

--- a/src/metasploit/msfconsole.py
+++ b/src/metasploit/msfconsole.py
@@ -8,7 +8,7 @@ __copyright__ = 'Copyright 2021, PyMetasploit Project'
 __credits__ = []
 
 __license__ = 'GPL'
-__version__ = '2.0'
+__version__ = '2.1'
 __maintainer__ = 'Nadeem Douba'
 __email__ = 'ndouba@cygnos.com'
 __status__ = 'Development'

--- a/src/metasploit/msfrpc.py
+++ b/src/metasploit/msfrpc.py
@@ -208,8 +208,7 @@ class MsfRpcClient(object):
                 self.client = HTTPSConnection(self.server, self.port, context=ssl._create_unverified_context())
         else:
             self.client = HTTPConnection(self.server, self.port)
-        self.username = kwargs.get('credentials').get('username', 'msf')
-        self.login(self.username, password)
+        self.login(kwargs.get('username', 'msf'), password)
 
     def call(self, method, *args):
         """
@@ -313,11 +312,18 @@ class MsfRpcClient(object):
         if self.sessionid is None:
             r = self.call(MsfRpcMethod.AuthLogin, username, password)
             # in case r is actually encoded in bytes, this is a safe way to turn it back to string for the try/catch
-            str_data = {
-                key.decode() if isinstance(key, bytes) else key:
-                    val.decode() if isinstance(val, bytes) else val
-                for key, val in r.items()
-            }
+            str_data = {}
+            for key, val in r.items():
+                if isinstance(key, bytes):
+                    key_temp = key.decode()
+                else:
+                    key_temp = key
+                if isinstance(val, bytes):
+                    val_temp = val.decode()
+                else:
+                    val_temp = val
+                str_data[key_temp] = val_temp
+
             try:
                 if str_data['result'] == 'success':
                     self.sessionid = str_data['token']

--- a/src/metasploit/utils.py
+++ b/src/metasploit/utils.py
@@ -7,7 +7,7 @@ __copyright__ = 'Copyright 2021, PyMetasploit Project'
 __credits__ = []
 
 __license__ = 'GPL'
-__version__ = '2.0'
+__version__ = '2.1'
 __maintainer__ = 'Nadeem Douba'
 __email__ = 'ndouba@gmail.com'
 __status__ = 'Development'

--- a/src/scripts/pymsfconsole
+++ b/src/scripts/pymsfconsole
@@ -15,7 +15,7 @@ __copyright__ = 'Copyright 2021, PyMetasploit Project'
 __credits__ = []
 
 __license__ = 'GPL'
-__version__ = '2.0'
+__version__ = '2.1'
 __maintainer__ = 'Nadeem Douba'
 __email__ = 'ndouba@cygnos.com'
 __status__ = 'Development'

--- a/src/scripts/pymsfrpc
+++ b/src/scripts/pymsfrpc
@@ -13,7 +13,7 @@ __copyright__ = 'Copyright 2021, PyMetasploit Project'
 __credits__ = []
 
 __license__ = 'GPL'
-__version__ = '2.0'
+__version__ = '2.1'
 __maintainer__ = 'Nadeem Douba'
 __email__ = 'ndouba@cygnos.com'
 __status__ = 'Development'


### PR DESCRIPTION
Needed to restructure credentials parameter to match the pymetasploit plugin.
Returns from the metasploit server are in bytes, added a check and conversion for this case into a string we can use to verify login success