### PR TITLE
Additional Fixes to underlying metasploit library

### DIFF
--- a/src/metasploit/utils.py
+++ b/src/metasploit/utils.py
@@ -32,7 +32,7 @@ def parseargs():
     return o
 
 
-def convert_bytes_to_string(bytes_dict: dict):
+def convert_bytes_to_string(bytes_dict: dict) -> dict:
     """
     :param bytes_dict: dictionary, where inner objects are strings, bytes, or collections of those types
     :return: original dictionary with any bytes values converted to strings

--- a/src/metasploit/utils.py
+++ b/src/metasploit/utils.py
@@ -59,7 +59,7 @@ def convert_bytes_to_string(bytes_dict: dict) -> dict:
 def convert_val(bytes_obj: iter):
     """
     :param bytes_obj: some object containing either string or byte values, can be collection or just bytes
-    :return: object containing original strings and converted bytes to strings
+    :return: iterable object (tuple or list) containing original strings and converted bytes to strings
     """
     for index, item in enumerate(bytes_obj):
         if isinstance(item, bytes):

--- a/src/metasploit/utils.py
+++ b/src/metasploit/utils.py
@@ -32,7 +32,11 @@ def parseargs():
     return o
 
 
-def convert_bytes_to_string(bytes_dict):
+def convert_bytes_to_string(bytes_dict: dict):
+    """
+    :param bytes_dict: dictionary, where inner objects are strings, bytes, or collections of those types
+    :return: original dictionary with any bytes values converted to strings
+    """
     str_data = {}
     if isinstance(bytes_dict, dict):
         for key, val in bytes_dict.items():
@@ -52,12 +56,17 @@ def convert_bytes_to_string(bytes_dict):
     return str_data
 
 
-def convert_val(bytes_obj):
+def convert_val(bytes_obj: iter):
+    """
+    :param bytes_obj: some object containing either string or byte values, can be collection or just bytes
+    :return: object containing original strings and converted bytes to strings
+    """
     for index, item in enumerate(bytes_obj):
         if isinstance(item, bytes):
             bytes_obj[index] = item.decode('utf-8')
         elif isinstance(item, dict):
             item = convert_bytes_to_string(item)
+            bytes_obj[index] = item
         elif isinstance(item, tuple) or isinstance(item, list):
-            convert_val(item)
+            bytes_obj[index] = convert_val(item)
     return bytes_obj

--- a/src/metasploit/utils.py
+++ b/src/metasploit/utils.py
@@ -30,3 +30,34 @@ def parseargs():
         p.print_help()
         exit(-1)
     return o
+
+
+def convert_bytes_to_string(bytes_dict):
+    str_data = {}
+    if isinstance(bytes_dict, dict):
+        for key, val in bytes_dict.items():
+            if isinstance(key, bytes):
+                key_temp = key.decode()
+            else:
+                key_temp = key
+            if isinstance(val, list) or isinstance(val, tuple):
+                val_temp = convert_val(val)
+            elif isinstance(val, dict):
+                val_temp = convert_bytes_to_string(val)
+            elif isinstance(val, bytes):
+                val_temp = val.decode()
+            else:
+                val_temp = val
+            str_data[key_temp] = val_temp
+    return str_data
+
+
+def convert_val(bytes_obj):
+    for index, item in enumerate(bytes_obj):
+        if isinstance(item, bytes):
+            bytes_obj[index] = item.decode('utf-8')
+        elif isinstance(item, dict):
+            item = convert_bytes_to_string(item)
+        elif isinstance(item, tuple) or isinstance(item, list):
+            convert_val(item)
+    return bytes_obj


### PR DESCRIPTION
Added 2 functions:
In utils.py, a function to decode bytes inside of objects into their string values
In msfrpc, a "close" function. Sometimes we might want to close the underlying connection before this object is thrown away to prevent a python warning (leaving open sockets isn't great in general)